### PR TITLE
Aip creation fix

### DIFF
--- a/earkcore/fixity/ChecksumFile.py
+++ b/earkcore/fixity/ChecksumFile.py
@@ -18,8 +18,13 @@ def get_sha256_hash(file):
     hash = hashlib.sha256()
     print file
     with open(file, 'rb') as file:
-        for block in iter(lambda: file.read(blocksize), ''):
-            hash.update(block)
+        # for block in iter(lambda: file.read(blocksize), ''):
+        #     hash.update(block)
+        while True:
+            buf = file.read(blocksize)
+            if not buf:
+                break
+            hash.update(buf)
     return hash.hexdigest()
 
 def checksum(file_path, wd=None, alg=ChecksumAlgorithm.SHA256):

--- a/earkcore/metadata/mets/MetsValidation.py
+++ b/earkcore/metadata/mets/MetsValidation.py
@@ -128,9 +128,9 @@ class MetsValidation(object):
         log = []
 
         # get information about the file
-        attr_path =  file.getchildren()[0].attrib[q(XLINK_NS,'href')]
+        attr_path = file.getchildren()[0].attrib[q(XLINK_NS, 'href')]
         attr_size = file.attrib['SIZE']
-        attr_checksum = file.attrib['CHECKSUM']
+        attr_checksum = file.attrib['CHECKSUM'].lower() # just in case someone creates a checksum with uppercase letters
         attr_checksumtype = file.attrib['CHECKSUMTYPE']
         # mimetpye = file.attrib['MIMETYPE']
 

--- a/earkcore/metadata/mets/metsgenerator.py
+++ b/earkcore/metadata/mets/metsgenerator.py
@@ -1,10 +1,8 @@
 import os
 from lxml import etree, objectify
 import unittest
-import hashlib
 import uuid
 from mimetypes import MimeTypes
-from config.config import root_dir
 from subprocess import Popen, PIPE
 from earkcore.utils.datetimeutils import current_timestamp, DT_ISO_FMT_SEC_PREC, get_file_ctime_iso_date_str
 from earkcore.format.formatidentification import FormatIdentification
@@ -42,16 +40,6 @@ class MetsGenerator(object):
     def __init__(self, root_path):
         print "Working in rootdir %s" % root_path
         self.root_path = root_path
-
-    # def sha256(self, fname):
-    #     hash = hashlib.sha256()
-    #     with open(fname, 'rb') as f:
-    #         while True:
-    #             buf = f.read(65536)
-    #             if not buf:
-    #                 break
-    #             hash.update(buf)
-    #     return hash.hexdigest()
 
     def runCommand(self, program, stdin=PIPE, stdout=PIPE, stderr=PIPE):
         result, res_stdout, res_stderr = None, None, None

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -511,7 +511,8 @@ class SIPRestructuring(DefaultTask):
                 tl.addinfo("Restructuring content of package: %s" % str(delivery))
 
                 # TODO: maybe remove the state.xml already during SIP packaging
-                os.remove(os.path.join(str(delivery), 'state.xml'))
+                if os.path.exists(os.path.join(str(delivery), 'state.xml')):
+                    os.remove(os.path.join(str(delivery), 'state.xml'))
 
                 fs_childs =  os.listdir(str(delivery))
                 for fs_child in fs_childs:
@@ -551,17 +552,20 @@ class SIPValidation(DefaultTask):
                 tl.adderr(("%s missing: %s" % (descr, os.path.abspath(f))))
 
         submission_path = os.path.join(task_context.path, "submission")
-        check_file("SIP METS file", os.path.join(submission_path, "METS.xml"))
+        check_file("submission METS file", os.path.join(submission_path, "METS.xml"))
         #check_file("Data directory", os.path.join(reps_path, "data"))
 
         #check_file("Documentation directory", os.path.join(path, "documentation"))
         #check_file("Metadata directory", os.path.join(path, "metadata"))
-        representations_path = os.path.join(task_context.path, "submission/representations")
-        for name in os.listdir(representations_path):
-            rep_path = os.path.join(representations_path, name)
-            if os.path.isdir(rep_path):
-                mets_validator = MetsValidation(rep_path)
-                valid = mets_validator.validate_mets(os.path.join(rep_path, 'METS.xml'))
+
+        # submission is not mandatory in an AIP:
+        if os.path.exists(os.path.join(task_context.path, "submission/representations")):
+            representations_path = os.path.join(task_context.path, "submission/representations")
+            for name in os.listdir(representations_path):
+                rep_path = os.path.join(representations_path, name)
+                if os.path.isdir(rep_path):
+                    mets_validator = MetsValidation(rep_path)
+                    valid = mets_validator.validate_mets(os.path.join(rep_path, 'METS.xml'))
 
         # currently: forced valid = True, until valid mets files are created by the SIP creator!
         # valid = True


### PR DESCRIPTION
- fixed faulty checksum creation
- checksums with uppercase chars (taken from METS) no longer cause errors
- state.xml can now be missing
